### PR TITLE
feat(middleware): add Logger middleware

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+  	"fmt"
+  	"net/http"
+  	"time"
+
+  	zlog "github.com/zenqos/zenqo/internal/log"
+  )
+
+// responseRecorder wraps http.ResponseWriter to capture the HTTP status code
+// written by the downstream handler.
+type responseRecorder struct {
+  	http.ResponseWriter
+  	status int
+  }
+
+func (rr *responseRecorder) WriteHeader(code int) {
+  	rr.status = code
+  	rr.ResponseWriter.WriteHeader(code)
+  }
+
+// Logger returns a middleware that logs each request with its HTTP method,
+// request path, response status code, elapsed time, and client IP address.
+//
+// Example:
+//
+//	app.Use(middleware.Logger())
+func Logger() func(http.Handler) http.Handler {
+  	return func(next http.Handler) http.Handler {
+      		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            			start := time.Now()
+            			rec := &responseRecorder{ResponseWriter: w, status: http.StatusOK}
+            			next.ServeHTTP(rec, r)
+
+            			duration := time.Since(start)
+            			msg := fmt.Sprintf("%d | %-7s | %-30s | %s | %v",
+                                     				rec.status, r.Method, r.URL.Path, r.RemoteAddr, duration)
+            			zlog.Log("Logger", msg)
+            		})
+      	}
+  }


### PR DESCRIPTION
## Summary
Adds a `Logger()` middleware to the `middleware` package that logs each HTTP request with:
- HTTP method
- - Request path  
- - Response status code
- - Elapsed time
- - Client IP address
The middleware uses the project's internal `zlog` package for structured, formatted output.

## Usage
```go
app.Use(middleware.Logger())
```

## Example Output
```
[Zenqo] 2026/02/26 14:00:00 LOG [Logger] 200 | GET     | /api/users                    | 127.0.0.1:55123 | 1.234ms
```

Closes #10