### PR TITLE
fix(examples/auth): add missing go.sum

### DIFF
--- a/examples/auth/go.sum
+++ b/examples/auth/go.sum
@@ -1,0 +1,4 @@
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=


### PR DESCRIPTION
## Summary
The `examples/auth` directory was missing a `go.sum` file, causing `go build .` to fail.

This commit adds the `go.sum` generated by running `go mod tidy` in `examples/auth/`, containing the cryptographic hashes for:
- `github.com/golang-jwt/jwt/v5 v5.2.1` (direct dependency)
- - `github.com/go-chi/chi/v5 v5.2.1` (transitive dependency via zenqo)
Closes #8