### PR TITLE
fix :: deduplicate guardToMiddleware implementation

### DIFF
--- a/core/middleware.go
+++ b/core/middleware.go
@@ -95,17 +95,9 @@ func guardReject(w http.ResponseWriter, err error) {
 
 // guardToMiddleware converts a Guard into a MiddlewareFunc that routes
 // rejections through the given ErrorHandlerFunc.
+// Delegates to GuardToMiddleware to avoid duplicating rejection logic.
 func guardToMiddleware(g Guard, errHandler ErrorHandlerFunc) MiddlewareFunc {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			allowed, err := g.CanActivate(r)
-			if !allowed {
-				guardRejectWith(w, r, err, errHandler)
-				return
-			}
-			next.ServeHTTP(w, r)
-		})
-	}
+	return GuardToMiddleware(g, errHandler)
 }
 
 // guardRejectWith routes a guard rejection through the given error handler.


### PR DESCRIPTION
## PR Checklist

- [x] Commit messages follow the project convention (`type :: scope - description`)
- [ ] Tests have been added or updated for bug fixes / new features
- [ ] Docs have been added or updated where necessary

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Code style update (formatting, naming)
- [ ] Build related changes
- [ ] Documentation
- [ ] Other — please describe:

## Related Issue

Closes #79

## New Behavior

- **#79** — `guardToMiddleware` now delegates to `GuardToMiddleware` instead of duplicating the rejection logic. Both internal and external callers now share a single implementation path, eliminating the risk of behavioral divergence on future changes.

## Breaking Changes

- [ ] Yes
- [x] No

## Additional Context

Note: Issue #74 (URL validation allowing non-HTTP/HTTPS schemes) was already fixed in `core/rules.go:166` — the condition `u.Scheme != "http" && u.Scheme != "https"` was added in a prior security hardening commit.
