### PR TITLE
fix :: strengthen RealIP warning and recommend RealIPWithConfig

### DIFF
--- a/middleware/realip.go
+++ b/middleware/realip.go
@@ -10,11 +10,19 @@ import (
 // extracted from X-Forwarded-For or X-Real-Ip headers.
 //
 // WARNING: This middleware unconditionally trusts the forwarded headers.
-// Only use it behind a trusted reverse proxy; otherwise clients can
-// spoof their IP address, bypassing rate limiting and IP-based security controls.
+// Any client can send a spoofed X-Forwarded-For header, bypassing
+// rate limiting, audit logging, and any IP-based access controls.
 //
-// For deployments where only specific proxy IPs should be trusted, use
-// RealIPWithConfig with a TrustedProxies list instead.
+// Only use RealIP when ALL of the following are true:
+//   - The application sits behind a trusted reverse proxy (nginx, AWS ALB, etc.)
+//   - The proxy strips or overwrites X-Forwarded-For before forwarding
+//
+// For production deployments, prefer RealIPWithConfig with an explicit
+// TrustedProxies allowlist so only headers from known proxy CIDRs are trusted:
+//
+//	app.Use(middleware.RealIPWithConfig(middleware.RealIPConfig{
+//	    TrustedProxies: []string{"10.0.0.0/8", "172.16.0.0/12"},
+//	}))
 func RealIP(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if ip := realIPFromHeaders(r); ip != "" {


### PR DESCRIPTION
## PR Checklist

- [x] Commit messages follow the project convention (`type :: scope - description`)
- [ ] Tests have been added or updated for bug fixes / new features
- [x] Docs have been added or updated where necessary

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Code style update (formatting, naming)
- [ ] Build related changes
- [ ] Documentation
- [ ] Other — please describe:

## Related Issue

Closes #75

## New Behavior

- **#75** — The `RealIP` middleware docstring now explicitly lists the conditions under which it is safe to use, and prominently recommends `RealIPWithConfig` with a `TrustedProxies` allowlist for production deployments. The original warning existed but was too brief to communicate the full IP-spoofing risk (rate limit bypass, audit log spoofing, access control bypass).

## Breaking Changes

- [ ] Yes
- [x] No

## Additional Context

No code logic was changed — only documentation. The safe alternative (`RealIPWithConfig`) already existed; this PR makes it the clearly recommended default.
