### PR TITLE
feat :: openapi - add /openapi.yaml endpoint and configurable spec formats

### DIFF
--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -18,31 +18,31 @@
 package openapi
 
 import (
-		"encoding/json"
-		"fmt"
-		"html"
-		"net/http"
-		"sync"
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+	"sync"
 
-		"github.com/zenqos/zenqo/core"
-		zlog "github.com/zenqos/zenqo/internal/log"
-	)
+	"github.com/zenqos/zenqo/core"
+	zlog "github.com/zenqos/zenqo/internal/log"
+)
 
 // Config holds metadata for the generated OpenAPI spec.
 type Config struct {
-		// Title is the API name shown in Swagger UI (required).
-		Title string
-		// Version is the API version string (default: "1.0.0").
-		Version string
-		// Description is an optional Markdown description shown in Swagger UI.
-		Description string
-		// SpecPath is the URL path that serves the JSON spec (default: "/openapi.json").
-		SpecPath string
-		// YAMLPath is the URL path that serves the YAML spec (default: "/openapi.yaml").
-		// Set to "-" to disable the YAML endpoint.
-		YAMLPath string
-		// DocsPath is the URL path that serves the Swagger UI (default: "/docs").
-		DocsPath string
+	// Title is the API name shown in Swagger UI (required).
+	Title string
+	// Version is the API version string (default: "1.0.0").
+	Version string
+	// Description is an optional Markdown description shown in Swagger UI.
+	Description string
+	// SpecPath is the URL path that serves the JSON spec (default: "/openapi.json").
+	SpecPath string
+	// YAMLPath is the URL path that serves the YAML spec (default: "/openapi.yaml").
+	// Set to "-" to disable the YAML endpoint.
+	YAMLPath string
+	// DocsPath is the URL path that serves the Swagger UI (default: "/docs").
+	DocsPath string
 }
 
 // Mount registers the OpenAPI JSON spec and Swagger UI endpoints on the app.
@@ -56,100 +56,100 @@ type Config struct {
 //   - GET {YAMLPath}  → application/yaml OpenAPI 3.1 spec (set YAMLPath to "-" to disable)
 //   - GET {DocsPath}  → Swagger UI HTML
 func Mount(app *core.App, cfg Config) {
-		if cfg.Version == "" {
-					cfg.Version = "1.0.0"
-				}
-		if cfg.SpecPath == "" {
-					cfg.SpecPath = "/openapi.json"
-				}
-		if cfg.YAMLPath == "" {
-					cfg.YAMLPath = "/openapi.yaml"
-				}
-		if cfg.DocsPath == "" {
-					cfg.DocsPath = "/docs"
-				}
+	if cfg.Version == "" {
+		cfg.Version = "1.0.0"
+	}
+	if cfg.SpecPath == "" {
+		cfg.SpecPath = "/openapi.json"
+	}
+	if cfg.YAMLPath == "" {
+		cfg.YAMLPath = "/openapi.yaml"
+	}
+	if cfg.DocsPath == "" {
+		cfg.DocsPath = "/docs"
+	}
 
-		specPath := cfg.SpecPath
-		yamlPath := cfg.YAMLPath
-		docsPath := cfg.DocsPath
+	specPath := cfg.SpecPath
+	yamlPath := cfg.YAMLPath
+	docsPath := cfg.DocsPath
 
-		// The Swagger UI must fetch the spec using the full URL path (including any
-		// global prefix set via app.SetGlobalPrefix), so the browser request resolves
-		// correctly regardless of which path the docs page is served from.
-		fullSpecURL := app.Prefix() + specPath
+	// The Swagger UI must fetch the spec using the full URL path (including any
+	// global prefix set via app.SetGlobalPrefix), so the browser request resolves
+	// correctly regardless of which path the docs page is served from.
+	fullSpecURL := app.Prefix() + specPath
 
-		// Pre-escape template values to prevent XSS via crafted Config.Title or SpecPath.
-		// - Title is placed inside an HTML <title> tag → HTML-escape.
-		// - fullSpecURL is placed inside a JS string literal → JSON-encode (includes quotes).
-		escapedTitle := html.EscapeString(cfg.Title)
-		urlJSON, _ := json.Marshal(fullSpecURL) // e.g. `"/api/openapi.json"`
+	// Pre-escape template values to prevent XSS via crafted Config.Title or SpecPath.
+	// - Title is placed inside an HTML <title> tag → HTML-escape.
+	// - fullSpecURL is placed inside a JS string literal → JSON-encode (includes quotes).
+	escapedTitle := html.EscapeString(cfg.Title)
+	urlJSON, _ := json.Marshal(fullSpecURL) // e.g. `"/api/openapi.json"`
 
-		// Spec generation is deferred to the first request so that all controllers
-		// registered after Mount() are included in the spec.
-		var (
-					once     sync.Once
-					specJSON []byte
-					specYAML []byte
-					buildErr error
-				)
+	// Spec generation is deferred to the first request so that all controllers
+	// registered after Mount() are included in the spec.
+	var (
+		once     sync.Once
+		specJSON []byte
+		specYAML []byte
+		buildErr error
+	)
 
-		generateSpec := func() {
-					routes := app.CollectRoutes()
-					sb := &schemaBuilder{
-									schemas:  make(map[string]*Schema),
-									building: make(map[string]bool),
-								}
-					spec := buildSpec(sb, cfg, routes)
-					if len(sb.schemas) > 0 {
-									spec.Components = &Components{Schemas: sb.schemas}
-								}
-					specJSON, buildErr = json.MarshalIndent(spec, "", "  ")
-					if buildErr != nil {
-									zlog.Err("OpenAPI", fmt.Sprintf("failed to marshal spec: %v", buildErr))
-									return
-								}
-					// Convert the JSON spec to YAML so both formats share one generation pass.
-					var yamlErr error
-					specYAML, yamlErr = jsonToYAML(specJSON)
-					if yamlErr != nil {
-									// YAML conversion failure is non-fatal; log and leave specYAML nil.
-									zlog.Err("OpenAPI", fmt.Sprintf("failed to convert spec to YAML: %v", yamlErr))
-								}
-				}
+	generateSpec := func() {
+		routes := app.CollectRoutes()
+		sb := &schemaBuilder{
+			schemas:  make(map[string]*Schema),
+			building: make(map[string]bool),
+		}
+		spec := buildSpec(sb, cfg, routes)
+		if len(sb.schemas) > 0 {
+			spec.Components = &Components{Schemas: sb.schemas}
+		}
+		specJSON, buildErr = json.MarshalIndent(spec, "", "  ")
+		if buildErr != nil {
+			zlog.Err("OpenAPI", fmt.Sprintf("failed to marshal spec: %v", buildErr))
+			return
+		}
+		// Convert the JSON spec to YAML so both formats share one generation pass.
+		var yamlErr error
+		specYAML, yamlErr = jsonToYAML(specJSON)
+		if yamlErr != nil {
+			// YAML conversion failure is non-fatal; log and leave specYAML nil.
+			zlog.Err("OpenAPI", fmt.Sprintf("failed to convert spec to YAML: %v", yamlErr))
+		}
+	}
 
-		ctrl := &openAPICtrl{}
-		ctrl.SetBasePath("/")
-		ctrl.Handle("GET", specPath, func(w http.ResponseWriter, r *http.Request) {
-					once.Do(generateSpec)
-					if buildErr != nil {
-									http.Error(w, `{"code":500,"message":"failed to generate OpenAPI spec"}`, http.StatusInternalServerError)
-									return
-								}
-					w.Header().Set("Content-Type", "application/json")
-					w.Header().Set("Access-Control-Allow-Origin", "*")
-					w.WriteHeader(http.StatusOK)
-					w.Write(specJSON) //nolint:errcheck
-				})
-		if yamlPath != "-" {
-					ctrl.Handle("GET", yamlPath, func(w http.ResponseWriter, r *http.Request) {
-									once.Do(generateSpec)
-									if buildErr != nil {
-														http.Error(w, `{"code":500,"message":"failed to generate OpenAPI spec"}`, http.StatusInternalServerError)
-														return
-													}
-									if specYAML == nil {
-														http.Error(w, `{"code":500,"message":"failed to convert spec to YAML"}`, http.StatusInternalServerError)
-														return
-													}
-									w.Header().Set("Content-Type", "application/yaml")
-									w.Header().Set("Access-Control-Allow-Origin", "*")
-									w.WriteHeader(http.StatusOK)
-									w.Write(specYAML) //nolint:errcheck
-								})
-				}
-		ctrl.Handle("GET", docsPath, func(w http.ResponseWriter, r *http.Request) {
-					w.Header().Set("Content-Type", "text/html; charset=utf-8")
-					fmt.Fprintf(w, swaggerUIHTML, escapedTitle, string(urlJSON)) //nolint:errcheck
-				})
-		app.UseController(ctrl)
+	ctrl := &openAPICtrl{}
+	ctrl.SetBasePath("/")
+	ctrl.Handle("GET", specPath, func(w http.ResponseWriter, r *http.Request) {
+		once.Do(generateSpec)
+		if buildErr != nil {
+			http.Error(w, `{"code":500,"message":"failed to generate OpenAPI spec"}`, http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.WriteHeader(http.StatusOK)
+		w.Write(specJSON) //nolint:errcheck
+	})
+	if yamlPath != "-" {
+		ctrl.Handle("GET", yamlPath, func(w http.ResponseWriter, r *http.Request) {
+			once.Do(generateSpec)
+			if buildErr != nil {
+				http.Error(w, `{"code":500,"message":"failed to generate OpenAPI spec"}`, http.StatusInternalServerError)
+				return
+			}
+			if specYAML == nil {
+				http.Error(w, `{"code":500,"message":"failed to convert spec to YAML"}`, http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.WriteHeader(http.StatusOK)
+			w.Write(specYAML) //nolint:errcheck
+		})
+	}
+	ctrl.Handle("GET", docsPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, swaggerUIHTML, escapedTitle, string(urlJSON)) //nolint:errcheck
+	})
+	app.UseController(ctrl)
 }

--- a/openapi/yaml.go
+++ b/openapi/yaml.go
@@ -1,12 +1,12 @@
 package openapi
 
 import (
-  	"encoding/json"
-  	"fmt"
-  	"sort"
-  	"strconv"
-  	"strings"
-  )
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
 
 // jsonToYAML converts a JSON-encoded document to block-style YAML.
 //
@@ -15,139 +15,139 @@ import (
 // output is always stable — map keys are sorted alphabetically — which is
 // important for diffing and caching.
 func jsonToYAML(data []byte) ([]byte, error) {
-  	var root any
-  	if err := json.Unmarshal(data, &root); err != nil {
-	  		return nil, fmt.Errorf("jsonToYAML: %w", err)
-	  	}
-  	var buf strings.Builder
-  	emitYAML(&buf, root, 0)
-  	return []byte(buf.String()), nil
-  }
+	var root any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("jsonToYAML: %w", err)
+	}
+	var buf strings.Builder
+	emitYAML(&buf, root, 0)
+	return []byte(buf.String()), nil
+}
 
 // emitYAML writes v to buf as YAML at the given indentation depth.
 func emitYAML(buf *strings.Builder, v any, depth int) {
-  	pad := strings.Repeat("  ", depth)
+	pad := strings.Repeat("  ", depth)
 
-  	switch val := v.(type) {
-	  	case map[string]any:
-	  		keys := make([]string, 0, len(val))
-	  		for k := range val {
-						keys = append(keys, k)
-					}
-	  		sort.Strings(keys)
+	switch val := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(val))
+		for k := range val {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
 
-	  		for _, k := range keys {
-						child := val[k]
-						buf.WriteString(pad)
-						buf.WriteString(yamlKey(k))
-						buf.WriteByte(':')
-						switch child.(type) {
-								case map[string]any, []any:
-									buf.WriteByte('\n')
-									emitYAML(buf, child, depth+1)
-								default:
-									buf.WriteByte(' ')
-									emitYAMLScalar(buf, child)
-								}
-					}
+		for _, k := range keys {
+			child := val[k]
+			buf.WriteString(pad)
+			buf.WriteString(yamlKey(k))
+			buf.WriteByte(':')
+			switch child.(type) {
+			case map[string]any, []any:
+				buf.WriteByte('\n')
+				emitYAML(buf, child, depth+1)
+			default:
+				buf.WriteByte(' ')
+				emitYAMLScalar(buf, child)
+			}
+		}
 
-	  	case []any:
-	  		for _, item := range val {
-						buf.WriteString(pad)
-						buf.WriteString("- ")
-						switch item.(type) {
-								case map[string]any, []any:
-									buf.WriteByte('\n')
-									emitYAML(buf, item, depth+1)
-								default:
-									emitYAMLScalar(buf, item)
-								}
-					}
+	case []any:
+		for _, item := range val {
+			buf.WriteString(pad)
+			buf.WriteString("- ")
+			switch item.(type) {
+			case map[string]any, []any:
+				buf.WriteByte('\n')
+				emitYAML(buf, item, depth+1)
+			default:
+				emitYAMLScalar(buf, item)
+			}
+		}
 
-	  	default:
-	  		emitYAMLScalar(buf, v)
-	  	}
-  }
+	default:
+		emitYAMLScalar(buf, v)
+	}
+}
 
 // emitYAMLScalar writes a leaf value followed by a newline.
 func emitYAMLScalar(buf *strings.Builder, v any) {
-  	switch val := v.(type) {
-	  	case string:
-	  		buf.WriteString(yamlString(val))
-	  	case float64:
-	  		if val == float64(int64(val)) {
-						buf.WriteString(strconv.FormatInt(int64(val), 10))
-					} else {
-						buf.WriteString(strconv.FormatFloat(val, 'f', -1, 64))
-					}
-	  	case bool:
-	  		if val {
-						buf.WriteString("true")
-					} else {
-						buf.WriteString("false")
-					}
-	  	case nil:
-	  		buf.WriteString("null")
-	  	default:
-	  		buf.WriteString(fmt.Sprintf("%v", v))
-	  	}
-  	buf.WriteByte('\n')
-  }
+	switch val := v.(type) {
+	case string:
+		buf.WriteString(yamlString(val))
+	case float64:
+		if val == float64(int64(val)) {
+			buf.WriteString(strconv.FormatInt(int64(val), 10))
+		} else {
+			buf.WriteString(strconv.FormatFloat(val, 'f', -1, 64))
+		}
+	case bool:
+		if val {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+	case nil:
+		buf.WriteString("null")
+	default:
+		buf.WriteString(fmt.Sprintf("%v", v))
+	}
+	buf.WriteByte('\n')
+}
 
 // yamlKey returns a safely-quoted YAML mapping key.
 func yamlKey(k string) string {
-  	if needsYAMLQuoting(k) {
-	  		return `"` + yamlEscape(k) + `"`
-	  	}
-  	return k
-  }
+	if needsYAMLQuoting(k) {
+		return `"` + yamlEscape(k) + `"`
+	}
+	return k
+}
 
 // yamlString returns a safely-quoted YAML scalar string.
 func yamlString(s string) string {
-  	if s == "" || isYAMLReserved(s) || needsYAMLQuoting(s) {
-	  		return `"` + yamlEscape(s) + `"`
-	  	}
-  	return s
-  }
+	if s == "" || isYAMLReserved(s) || needsYAMLQuoting(s) {
+		return `"` + yamlEscape(s) + `"`
+	}
+	return s
+}
 
 // needsYAMLQuoting reports whether s contains characters that have special
 // meaning in YAML and therefore require the string to be quoted.
 func needsYAMLQuoting(s string) bool {
-  	if s == "" {
-	  		return true
-	  	}
-  	if s[0] == ' ' || s[len(s)-1] == ' ' {
-	  		return true
-	  	}
-  	for _, c := range s {
-	  		switch c {
-					case ':', '#', '{', '}', '[', ']', ',', '&', '*', '?', '|',
-						'-', '<', '>', '=', '!', '%', '@', '`', '"', '\'', '\\',
-						'\n', '\r', '\t':
-						return true
-					}
-	  	}
-  	return false
-  }
+	if s == "" {
+		return true
+	}
+	if s[0] == ' ' || s[len(s)-1] == ' ' {
+		return true
+	}
+	for _, c := range s {
+		switch c {
+		case ':', '#', '{', '}', '[', ']', ',', '&', '*', '?', '|',
+			'-', '<', '>', '=', '!', '%', '@', '`', '"', '\'', '\\',
+			'\n', '\r', '\t':
+			return true
+		}
+	}
+	return false
+}
 
 // isYAMLReserved reports whether s is a YAML reserved word.
 func isYAMLReserved(s string) bool {
-  	switch strings.ToLower(s) {
-	  	case "true", "false", "null", "~", "yes", "no", "on", "off":
-	  		return true
-	  	}
-  	if _, err := strconv.ParseFloat(s, 64); err == nil {
-	  		return true
-	  	}
-  	return false
-  }
+	switch strings.ToLower(s) {
+	case "true", "false", "null", "~", "yes", "no", "on", "off":
+		return true
+	}
+	if _, err := strconv.ParseFloat(s, 64); err == nil {
+		return true
+	}
+	return false
+}
 
 // yamlEscape escapes backslashes and double-quotes inside a double-quoted YAML scalar.
 func yamlEscape(s string) string {
-  	s = strings.ReplaceAll(s, `\`, `\\`)
-  	s = strings.ReplaceAll(s, `"`, `\"`) 
-  	s = strings.ReplaceAll(s, "\n", `\n`)
-  	s = strings.ReplaceAll(s, "\r", `\r`)
-  	s = strings.ReplaceAll(s, "\t", `\t`)
-  	return s
-  }
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\t", `\t`)
+	return s
+}

--- a/openapi/yaml_test.go
+++ b/openapi/yaml_test.go
@@ -1,234 +1,234 @@
 package openapi
 
 import (
-  	"encoding/json"
-  	"net/http"
-  	"net/http/httptest"
-  	"strings"
-  	"testing"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
 
-  	"github.com/zenqos/zenqo/core"
-  )
+	"github.com/zenqos/zenqo/core"
+)
 
 // ---------------------------------------------------------------------------
 // Unit tests for the JSON → YAML converter
 // ---------------------------------------------------------------------------
 
 func TestJSONToYAML_SimpleObject(t *testing.T) {
-  	input := `{"title":"My API","version":"1.0.0"}`
-  	out, err := jsonToYAML([]byte(input))
-  	if err != nil {
-	  		t.Fatalf("unexpected error: %v", err)
-	  	}
-  	yaml := string(out)
+	input := `{"title":"My API","version":"1.0.0"}`
+	out, err := jsonToYAML([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	yaml := string(out)
 
-  	assertContains(t, yaml, "title: My API")
-  	assertContains(t, yaml, "version: 1.0.0")
-  }
+	assertContains(t, yaml, "title: My API")
+	assertContains(t, yaml, "version: 1.0.0")
+}
 
 func TestJSONToYAML_NestedObject(t *testing.T) {
-  	input := `{"info":{"title":"Test","version":"2.0"}}`
-  	out, err := jsonToYAML([]byte(input))
-  	if err != nil {
-	  		t.Fatalf("unexpected error: %v", err)
-	  	}
-  	yaml := string(out)
+	input := `{"info":{"title":"Test","version":"2.0"}}`
+	out, err := jsonToYAML([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	yaml := string(out)
 
-  	assertContains(t, yaml, "info:")
-  	assertContains(t, yaml, "  title: Test")
-  	// "2.0" is a string in JSON; the converter must quote it so YAML parsers
-  	// treat it as a string rather than a float scalar.
-  	assertContains(t, yaml, `  version: "2.0"`)
-  }
+	assertContains(t, yaml, "info:")
+	assertContains(t, yaml, "  title: Test")
+	// "2.0" is a string in JSON; the converter must quote it so YAML parsers
+	// treat it as a string rather than a float scalar.
+	assertContains(t, yaml, `  version: "2.0"`)
+}
 
 func TestJSONToYAML_Array(t *testing.T) {
-  	input := `{"tags":["users","auth"]}`
-  	out, err := jsonToYAML([]byte(input))
-  	if err != nil {
-	  		t.Fatalf("unexpected error: %v", err)
-	  	}
-  	yaml := string(out)
+	input := `{"tags":["users","auth"]}`
+	out, err := jsonToYAML([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	yaml := string(out)
 
-  	assertContains(t, yaml, "tags:")
-  	assertContains(t, yaml, "- users")
-  	assertContains(t, yaml, "- auth")
-  }
+	assertContains(t, yaml, "tags:")
+	assertContains(t, yaml, "- users")
+	assertContains(t, yaml, "- auth")
+}
 
 func TestJSONToYAML_BooleanAndNull(t *testing.T) {
-  	input := `{"deprecated":true,"nullable":false,"example":null}`
-  	out, err := jsonToYAML([]byte(input))
-  	if err != nil {
-	  		t.Fatalf("unexpected error: %v", err)
-	  	}
-  	yaml := string(out)
+	input := `{"deprecated":true,"nullable":false,"example":null}`
+	out, err := jsonToYAML([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	yaml := string(out)
 
-  	assertContains(t, yaml, "deprecated: true")
-  	assertContains(t, yaml, "nullable: false")
-  	assertContains(t, yaml, "example: null")
-  }
+	assertContains(t, yaml, "deprecated: true")
+	assertContains(t, yaml, "nullable: false")
+	assertContains(t, yaml, "example: null")
+}
 
 func TestJSONToYAML_SpecialCharsInValue(t *testing.T) {
-  	input := `{"description":"Error: bad request","path":"/users/{id}"}`
-  	out, err := jsonToYAML([]byte(input))
-  	if err != nil {
-	  		t.Fatalf("unexpected error: %v", err)
-	  	}
-  	yaml := string(out)
-  	assertContains(t, yaml, `"Error: bad request"`)
-  }
+	input := `{"description":"Error: bad request","path":"/users/{id}"}`
+	out, err := jsonToYAML([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	yaml := string(out)
+	assertContains(t, yaml, `"Error: bad request"`)
+}
 
 func TestJSONToYAML_RefKey(t *testing.T) {
-  	input := `{"$ref":"#/components/schemas/User"}`
-  	out, err := jsonToYAML([]byte(input))
-  	if err != nil {
-	  		t.Fatalf("unexpected error: %v", err)
-	  	}
-  	yaml := string(out)
-  	assertContains(t, yaml, "$ref:")
-  }
+	input := `{"$ref":"#/components/schemas/User"}`
+	out, err := jsonToYAML([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	yaml := string(out)
+	assertContains(t, yaml, "$ref:")
+}
 
 func TestJSONToYAML_StableKeyOrder(t *testing.T) {
-  	input := `{"z":1,"a":2,"m":3}`
-  	out, err := jsonToYAML([]byte(input))
-  	if err != nil {
-	  		t.Fatalf("unexpected error: %v", err)
-	  	}
-  	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-  	if len(lines) != 3 {
-	  		t.Fatalf("expected 3 lines, got %d: %s", len(lines), out)
-	  	}
-  	if !strings.HasPrefix(lines[0], "a:") {
-	  		t.Errorf("first key should be 'a', got %q", lines[0])
-	  	}
-  	if !strings.HasPrefix(lines[1], "m:") {
-	  		t.Errorf("second key should be 'm', got %q", lines[1])
-	  	}
-  	if !strings.HasPrefix(lines[2], "z:") {
-	  		t.Errorf("third key should be 'z', got %q", lines[2])
-	  	}
-  }
+	input := `{"z":1,"a":2,"m":3}`
+	out, err := jsonToYAML([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %s", len(lines), out)
+	}
+	if !strings.HasPrefix(lines[0], "a:") {
+		t.Errorf("first key should be 'a', got %q", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "m:") {
+		t.Errorf("second key should be 'm', got %q", lines[1])
+	}
+	if !strings.HasPrefix(lines[2], "z:") {
+		t.Errorf("third key should be 'z', got %q", lines[2])
+	}
+}
 
 func TestJSONToYAML_InvalidInput(t *testing.T) {
-  	_, err := jsonToYAML([]byte("not valid json"))
-  	if err == nil {
-	  		t.Fatal("expected error for invalid JSON input")
-	  	}
-  }
+	_, err := jsonToYAML([]byte("not valid json"))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON input")
+	}
+}
 
 func TestJSONToYAML_RoundTrip(t *testing.T) {
-  	original := map[string]any{
-	  		"openapi": "3.1.0",
-	  		"info": map[string]any{
-						"title":   "Round-trip API",
-						"version": "0.1.0",
-					},
-	  		"paths": map[string]any{},
-	  	}
-  	jsonBytes, _ := json.Marshal(original)
-  	yamlBytes, err := jsonToYAML(jsonBytes)
-  	if err != nil {
-	  		t.Fatalf("unexpected error: %v", err)
-	  	}
-  	if len(yamlBytes) == 0 {
-	  		t.Fatal("expected non-empty YAML output")
-	  	}
-  	yaml := string(yamlBytes)
-  	assertContains(t, yaml, "openapi: 3.1.0")
-  	assertContains(t, yaml, "Round-trip API")
-  }
+	original := map[string]any{
+		"openapi": "3.1.0",
+		"info": map[string]any{
+			"title":   "Round-trip API",
+			"version": "0.1.0",
+		},
+		"paths": map[string]any{},
+	}
+	jsonBytes, _ := json.Marshal(original)
+	yamlBytes, err := jsonToYAML(jsonBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(yamlBytes) == 0 {
+		t.Fatal("expected non-empty YAML output")
+	}
+	yaml := string(yamlBytes)
+	assertContains(t, yaml, "openapi: 3.1.0")
+	assertContains(t, yaml, "Round-trip API")
+}
 
 // ---------------------------------------------------------------------------
 // Integration tests for the /openapi.yaml HTTP endpoint
 // ---------------------------------------------------------------------------
 
 func TestMount_YAMLEndpoint(t *testing.T) {
-  	app := core.NewApp()
+	app := core.NewApp()
 
-  	c := &core.BaseController{}
-  	c.SetBasePath("/users")
-  	c.GET("/{id}", func(r *http.Request) (any, error) {
-	  		return map[string]string{"id": "1"}, nil
-	  	}).Response(200, struct{ ID string }{})
-  	app.UseController(c)
+	c := &core.BaseController{}
+	c.SetBasePath("/users")
+	c.GET("/{id}", func(r *http.Request) (any, error) {
+		return map[string]string{"id": "1"}, nil
+	}).Response(200, struct{ ID string }{})
+	app.UseController(c)
 
-  	Mount(app, Config{Title: "Test API", Version: "1.0.0"})
+	Mount(app, Config{Title: "Test API", Version: "1.0.0"})
 
-  	w := httptest.NewRecorder()
-  	r := httptest.NewRequest("GET", "/openapi.yaml", nil)
-  	app.Handler().ServeHTTP(w, r)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/openapi.yaml", nil)
+	app.Handler().ServeHTTP(w, r)
 
-  	if w.Code != http.StatusOK {
-	  		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	  	}
-  	ct := w.Header().Get("Content-Type")
-  	if !strings.HasPrefix(ct, "application/yaml") {
-	  		t.Errorf("expected application/yaml Content-Type, got %q", ct)
-	  	}
-  	body := w.Body.String()
-  	assertContains(t, body, "openapi:")
-  	assertContains(t, body, "3.1.0")
-  	assertContains(t, body, "Test API")
-  }
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	ct := w.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/yaml") {
+		t.Errorf("expected application/yaml Content-Type, got %q", ct)
+	}
+	body := w.Body.String()
+	assertContains(t, body, "openapi:")
+	assertContains(t, body, "3.1.0")
+	assertContains(t, body, "Test API")
+}
 
 func TestMount_YAMLEndpoint_CustomPath(t *testing.T) {
-  	app := core.NewApp()
+	app := core.NewApp()
 
-  	Mount(app, Config{
-	  		Title:    "Test",
-	  		YAMLPath: "/spec.yaml",
-	  	})
+	Mount(app, Config{
+		Title:    "Test",
+		YAMLPath: "/spec.yaml",
+	})
 
-  	w := httptest.NewRecorder()
-  	r := httptest.NewRequest("GET", "/spec.yaml", nil)
-  	app.Handler().ServeHTTP(w, r)
-  	if w.Code != http.StatusOK {
-	  		t.Fatalf("expected 200 at /spec.yaml, got %d", w.Code)
-	  	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/spec.yaml", nil)
+	app.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 at /spec.yaml, got %d", w.Code)
+	}
 
-  	w2 := httptest.NewRecorder()
-  	r2 := httptest.NewRequest("GET", "/openapi.yaml", nil)
-  	app.Handler().ServeHTTP(w2, r2)
-  	if w2.Code == http.StatusOK {
-	  		t.Error("expected non-200 at /openapi.yaml when custom YAMLPath is set")
-	  	}
-  }
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest("GET", "/openapi.yaml", nil)
+	app.Handler().ServeHTTP(w2, r2)
+	if w2.Code == http.StatusOK {
+		t.Error("expected non-200 at /openapi.yaml when custom YAMLPath is set")
+	}
+}
 
 func TestMount_YAMLEndpoint_DisabledWithDash(t *testing.T) {
-  	app := core.NewApp()
-  	Mount(app, Config{Title: "Test", YAMLPath: "-"})
+	app := core.NewApp()
+	Mount(app, Config{Title: "Test", YAMLPath: "-"})
 
-  	w := httptest.NewRecorder()
-  	r := httptest.NewRequest("GET", "/openapi.yaml", nil)
-  	app.Handler().ServeHTTP(w, r)
-  	if w.Code == http.StatusOK {
-	  		t.Error("expected non-200 when YAML endpoint is disabled with '-'")
-	  	}
-  }
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/openapi.yaml", nil)
+	app.Handler().ServeHTTP(w, r)
+	if w.Code == http.StatusOK {
+		t.Error("expected non-200 when YAML endpoint is disabled with '-'")
+	}
+}
 
 func TestMount_JSONEndpointUnaffected(t *testing.T) {
-  	app := core.NewApp()
-  	Mount(app, Config{Title: "Test API", Version: "1.0.0"})
+	app := core.NewApp()
+	Mount(app, Config{Title: "Test API", Version: "1.0.0"})
 
-  	w := httptest.NewRecorder()
-  	r := httptest.NewRequest("GET", "/openapi.json", nil)
-  	app.Handler().ServeHTTP(w, r)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/openapi.json", nil)
+	app.Handler().ServeHTTP(w, r)
 
-  	if w.Code != http.StatusOK {
-	  		t.Fatalf("expected 200 at /openapi.json, got %d", w.Code)
-	  	}
-  	ct := w.Header().Get("Content-Type")
-  	if !strings.HasPrefix(ct, "application/json") {
-	  		t.Errorf("expected application/json, got %q", ct)
-	  	}
-  }
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 at /openapi.json, got %d", w.Code)
+	}
+	ct := w.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("expected application/json, got %q", ct)
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 func assertContains(t *testing.T, haystack, needle string) {
-  	t.Helper()
-  	if !strings.Contains(haystack, needle) {
-	  		t.Errorf("expected output to contain %q\ngot:\n%s", needle, haystack)
-	  	}
-  }
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected output to contain %q\ngot:\n%s", needle, haystack)
+	}
+}


### PR DESCRIPTION
Closes #34

## Summary

Add a `/openapi.yaml` endpoint alongside the existing `/openapi.json`, serving the same spec in human-readable block-style YAML. YAML is widely preferred for API tooling (Redoc, Speakeasy, code generators) and is now the default format in many API-first workflows.

### New features

- **`YAMLPath` config field** (default: `/openapi.yaml`) — set to `"-"` to disable
- - **Dependency-free JSON→YAML converter** (`yaml.go`):
-   - Recursive block-style emitter with stable (alphabetically sorted) keys for clean diffs
-   - Correct quoting for YAML special characters, reserved words (`true`, `false`, `null`), and strings that would be misinterpreted as numbers
- - **Single generation pass** — both JSON and YAML share the same `sync.Once` invocation
- - **Content-Type: application/yaml** with CORS header on the YAML endpoint
### API

```go
// Default: serves /openapi.json AND /openapi.yaml
openapi.Mount(app, openapi.Config{Title: "My API"})

// Custom YAML path:
openapi.Mount(app, openapi.Config{
    YAMLPath: "/spec.yaml",
})

// Disable YAML:
openapi.Mount(app, openapi.Config{
    YAMLPath: "-",
})
```

## PR Checklist
- [x] Commit messages follow the project convention
- [ ] - [x] No new dependencies (converter uses only stdlib `encoding/json`)
- [ ] - [x] Tests: unit tests for converter edge cases + HTTP integration tests