### PR TITLE
fix :: set Windows console to UTF-8 for non-ASCII output

### DIFF
--- a/internal/log/console_other.go
+++ b/internal/log/console_other.go
@@ -1,0 +1,3 @@
+//go:build !windows
+
+package zlog

--- a/internal/log/console_windows.go
+++ b/internal/log/console_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package zlog
+
+import "syscall"
+
+var (
+	kernel32               = syscall.NewLazyDLL("kernel32.dll")
+	procSetConsoleOutputCP = kernel32.NewProc("SetConsoleOutputCP")
+)
+
+func init() {
+	// Set console output code page to UTF-8 (65001) so non-ASCII characters
+	// (e.g. Korean PostgreSQL errors) render correctly on Windows.
+	procSetConsoleOutputCP.Call(65001) //nolint:errcheck
+}


### PR DESCRIPTION
## PR Checklist

- [x] Commit messages follow the project convention (`type :: scope - description`)
- [ ] Tests have been added or updated for bug fixes / new features
- [x] Docs have been added or updated where necessary

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Code style update (formatting, naming)
- [ ] Build related changes
- [ ] Documentation
- [ ] Other — please describe:

## Related Issue

Closes #91

## New Behavior

Windows 콘솔에서 non-ASCII 문자(한국어 PostgreSQL 에러 등)가 깨지지 않고 정상 출력됩니다.

- `internal/log` 패키지 init 시 Windows에서 콘솔 출력 코드페이지를 UTF-8(65001)로 설정
- `syscall`을 사용하여 외부 의존성 없이 `kernel32.dll`의 `SetConsoleOutputCP` 호출
- `//go:build` 태그로 Windows/non-Windows 분리

## Breaking Changes

- [ ] Yes
- [x] No

## Additional Context

- `console_windows.go` — Windows 전용 init (build tag: `windows`)
- `console_other.go` — non-Windows no-op (build tag: `!windows`)