### PR TITLE
feat :: show API docs URL in boot log

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -28,6 +28,7 @@ type App struct {
 	errorHandler    ErrorHandlerFunc
 	shutdownTimeout time.Duration
 	rfc9457         bool
+	docsPath        string // set by OpenAPI Mount to show docs URL at startup
 }
 
 // errorHandlerSetter is satisfied by any Controller that embeds BaseController.
@@ -103,6 +104,10 @@ func (a *App) SetGlobalPrefix(prefix string) *App {
 // Prefix returns the global URL prefix set via SetGlobalPrefix.
 // Returns an empty string if no prefix has been configured.
 func (a *App) Prefix() string { return a.prefix }
+
+// SetDocsPath stores the OpenAPI docs path for display at startup.
+// Called internally by openapi.Mount().
+func (a *App) SetDocsPath(path string) { a.docsPath = path }
 
 // SetShutdownTimeout sets the maximum duration to wait for in-flight requests
 // to complete when the server receives SIGINT or SIGTERM.
@@ -250,6 +255,9 @@ func (a *App) Start(addr string) error {
 	}
 	elapsed := time.Since(started).Milliseconds()
 	zlog.Log("Server", fmt.Sprintf("Listening on %s  +%dms", host, elapsed))
+	if a.docsPath != "" {
+		zlog.Log("Server", fmt.Sprintf("API Docs   %s%s", host, a.docsPath))
+	}
 
 	srv := &http.Server{
 		Addr:         addr,

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -170,4 +170,5 @@ func Mount(app *core.App, cfg Config) {
 		fmt.Fprintf(w, swaggerUIHTML, escapedTitle, string(urlJSON)) //nolint:errcheck
 	})
 	app.UseController(ctrl)
+	app.SetDocsPath(app.Prefix() + docsPath)
 }


### PR DESCRIPTION
## PR Checklist

- [x] Commit messages follow the project convention (`type :: scope - description`)
- [ ] Tests have been added or updated for bug fixes / new features
- [x] Docs have been added or updated where necessary

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Code style update (formatting, naming)
- [ ] Build related changes
- [ ] Documentation
- [ ] Other — please describe:

## Related Issue

Closes #92

## New Behavior

OpenAPI docs가 등록되어 있으면 서버 시작 시 docs URL이 자동으로 출력됩니다.

```
[Zenqo] LOG  [Server]  Listening on http://localhost:8080  +3ms
[Zenqo] LOG  [Server]  API Docs   http://localhost:8080/api/v1/docs
```

- `App` 구조체에 `docsPath` 필드 추가
- `SetDocsPath()` 메서드 추가 (openapi.Mount에서 호출)
- `Start()`에서 docsPath가 설정되어 있으면 URL 출력

## Breaking Changes

- [ ] Yes
- [x] No

## Additional Context

`openapi.Mount()` 호출 시 자동으로 `app.SetDocsPath()`가 호출되므로 사용자 코드 변경 불필요.