### PR TITLE
fix :: make tryItOutEnabled configurable in Swagger UI

### DIFF
--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -58,6 +58,9 @@ type Config struct {
 	//
 	// Set to false to opt out and document error responses manually.
 	AutoErrorResponses *bool
+	// TryItOutEnabled controls whether the "Try it out" button is pre-activated
+	// in Swagger UI for all endpoints (default: false — standard Swagger UI behavior).
+	TryItOutEnabled *bool
 	// UseRFC9457 controls the error schema used for auto-injected error
 	// responses. When true, ProblemDetail is used instead of ErrorResponse.
 	UseRFC9457 bool
@@ -101,6 +104,11 @@ func Mount(app *core.App, cfg Config) {
 	// - fullSpecURL is placed inside a JS string literal → JSON-encode (includes quotes).
 	escapedTitle := html.EscapeString(cfg.Title)
 	urlJSON, _ := json.Marshal(fullSpecURL) // e.g. `"/api/openapi.json"`
+
+	tryItOut := "false"
+	if cfg.TryItOutEnabled != nil && *cfg.TryItOutEnabled {
+		tryItOut = "true"
+	}
 
 	// Spec generation is deferred to the first request so that all controllers
 	// registered after Mount() are included in the spec.
@@ -167,7 +175,7 @@ func Mount(app *core.App, cfg Config) {
 	}
 	ctrl.Handle("GET", docsPath, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		fmt.Fprintf(w, swaggerUIHTML, escapedTitle, string(urlJSON)) //nolint:errcheck
+		fmt.Fprintf(w, swaggerUIHTML, escapedTitle, string(urlJSON), tryItOut) //nolint:errcheck
 	})
 	app.UseController(ctrl)
 }

--- a/openapi/ui.go
+++ b/openapi/ui.go
@@ -29,7 +29,7 @@ const swaggerUIHTML = `<!DOCTYPE html>
       deepLinking: true,
       presets: [SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset],
       layout: 'BaseLayout',
-      tryItOutEnabled: true,
+      tryItOutEnabled: %s,
     });
   </script>
 </body>


### PR DESCRIPTION
## PR Checklist

- [x] Commit messages follow the project convention (`type :: scope - description`)
- [ ] Tests have been added or updated for bug fixes / new features
- [x] Docs have been added or updated where necessary

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Code style update (formatting, naming)
- [ ] Build related changes
- [ ] Documentation
- [ ] Other — please describe:

## Related Issue

Closes #93

## New Behavior

`openapi.Config`에 `TryItOutEnabled *bool` 필드를 추가하여 Swagger UI의 "Try it out" 자동 활성화를 제어할 수 있습니다.

```go
// 기본값: false (표준 Swagger UI 동작)
openapi.Mount(app, openapi.Config{
    Title:   "My API",
    Version: "1.0.0",
})

// 명시적으로 활성화
enabled := true
openapi.Mount(app, openapi.Config{
    Title:           "My API",
    Version:         "1.0.0",
    TryItOutEnabled: &enabled,
})
```

- `Config.TryItOutEnabled` — `*bool` 타입, nil이면 기본값 false
- `ui.go` 템플릿에서 하드코딩된 `true` 제거, format placeholder로 대체

## Breaking Changes

- [ ] Yes
- [x] No

## Additional Context

기존에 `tryItOutEnabled: true`로 하드코딩되어 있던 것이 기본값 `false`로 변경됩니다. 기존 동작을 유지하려면 `TryItOutEnabled: &true`를 설정하면 됩니다.