### PR TITLE
feat :: add BindQueryStruct for typed query parameter binding

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -8,6 +8,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -80,6 +81,96 @@ func Bind[T any](r *http.Request) (T, error) {
 //	page := core.BindQuery(r, "page")  // GET /users?page=2
 func BindQuery(r *http.Request, key string) string {
 	return r.URL.Query().Get(key)
+}
+
+// BindQueryStruct binds URL query parameters to a typed struct.
+// Fields must be tagged with `query:"key"` to map query keys to struct fields.
+// Supports string, int, int64, uint, uint64, float32, float64, bool, and []string.
+// Validation tags (`validate:"..."`) are applied after binding.
+//
+// Example:
+//
+//	type ListQuery struct {
+//		Page  int    `query:"page"`
+//		Limit int    `query:"limit" validate:"max=100"`
+//		Sort  string `query:"sort"  validate:"oneof=asc|desc"`
+//		Tags  []string `query:"tag"`
+//	}
+//
+//	q, err := core.BindQueryStruct[ListQuery](r)
+func BindQueryStruct[T any](r *http.Request) (T, error) {
+	var v T
+	rv := reflect.ValueOf(&v).Elem()
+	rt := rv.Type()
+	query := r.URL.Query()
+
+	for i := 0; i < rt.NumField(); i++ {
+		sf := rt.Field(i)
+		if !sf.IsExported() {
+			continue
+		}
+		key := sf.Tag.Get("query")
+		if key == "" || key == "-" {
+			continue
+		}
+
+		fv := rv.Field(i)
+
+		// []string: collect all values for the key
+		if sf.Type == reflect.TypeOf([]string{}) {
+			if vals, ok := query[key]; ok {
+				fv.Set(reflect.ValueOf(vals))
+			}
+			continue
+		}
+
+		raw := query.Get(key)
+		if raw == "" {
+			continue
+		}
+
+		if err := setFieldFromString(fv, raw, key); err != nil {
+			return v, err
+		}
+	}
+
+	if err := validate(v); err != nil {
+		return v, err
+	}
+	return v, nil
+}
+
+// setFieldFromString converts a string value and sets it on the reflect.Value.
+func setFieldFromString(fv reflect.Value, raw, key string) error {
+	switch fv.Kind() {
+	case reflect.String:
+		fv.SetString(raw)
+	case reflect.Int, reflect.Int64:
+		n, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return ErrBadRequest(fmt.Sprintf("invalid query parameter %q: expected integer", key))
+		}
+		fv.SetInt(n)
+	case reflect.Uint, reflect.Uint64:
+		n, err := strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			return ErrBadRequest(fmt.Sprintf("invalid query parameter %q: expected unsigned integer", key))
+		}
+		fv.SetUint(n)
+	case reflect.Float32, reflect.Float64:
+		n, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return ErrBadRequest(fmt.Sprintf("invalid query parameter %q: expected number", key))
+		}
+		fv.SetFloat(n)
+	case reflect.Bool:
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return ErrBadRequest(fmt.Sprintf("invalid query parameter %q: expected boolean", key))
+		}
+		fv.SetBool(b)
+	}
+	return nil
 }
 
 // BindHeader reads a named header from the request.

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -150,6 +150,131 @@ func TestBindQuerySpecialChars(t *testing.T) {
 	}
 }
 
+// --- BindQueryStruct tests ---
+
+func TestBindQueryStructBasic(t *testing.T) {
+	type Q struct {
+		Page  int    `query:"page"`
+		Limit int    `query:"limit"`
+		Sort  string `query:"sort"`
+	}
+	r, _ := http.NewRequest("GET", "/users?page=2&limit=10&sort=asc", nil)
+	q, err := BindQueryStruct[Q](r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if q.Page != 2 {
+		t.Errorf("Page = %d, want 2", q.Page)
+	}
+	if q.Limit != 10 {
+		t.Errorf("Limit = %d, want 10", q.Limit)
+	}
+	if q.Sort != "asc" {
+		t.Errorf("Sort = %q, want %q", q.Sort, "asc")
+	}
+}
+
+func TestBindQueryStructSlice(t *testing.T) {
+	type Q struct {
+		Tags []string `query:"tag"`
+	}
+	r, _ := http.NewRequest("GET", "/search?tag=go&tag=rust", nil)
+	q, err := BindQueryStruct[Q](r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(q.Tags) != 2 || q.Tags[0] != "go" || q.Tags[1] != "rust" {
+		t.Errorf("Tags = %v, want [go rust]", q.Tags)
+	}
+}
+
+func TestBindQueryStructBoolFloat(t *testing.T) {
+	type Q struct {
+		Active bool    `query:"active"`
+		Score  float64 `query:"score"`
+	}
+	r, _ := http.NewRequest("GET", "/items?active=true&score=9.5", nil)
+	q, err := BindQueryStruct[Q](r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !q.Active {
+		t.Error("Active = false, want true")
+	}
+	if q.Score != 9.5 {
+		t.Errorf("Score = %f, want 9.5", q.Score)
+	}
+}
+
+func TestBindQueryStructMissing(t *testing.T) {
+	type Q struct {
+		Page int    `query:"page"`
+		Sort string `query:"sort"`
+	}
+	r, _ := http.NewRequest("GET", "/users", nil)
+	q, err := BindQueryStruct[Q](r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if q.Page != 0 {
+		t.Errorf("Page = %d, want 0", q.Page)
+	}
+	if q.Sort != "" {
+		t.Errorf("Sort = %q, want empty", q.Sort)
+	}
+}
+
+func TestBindQueryStructInvalidInt(t *testing.T) {
+	type Q struct {
+		Page int `query:"page"`
+	}
+	r, _ := http.NewRequest("GET", "/users?page=abc", nil)
+	_, err := BindQueryStruct[Q](r)
+	if err == nil {
+		t.Fatal("expected error for invalid int")
+	}
+}
+
+func TestBindQueryStructValidation(t *testing.T) {
+	type Q struct {
+		Limit int `query:"limit" validate:"max=100"`
+	}
+	r, _ := http.NewRequest("GET", "/users?limit=200", nil)
+	_, err := BindQueryStruct[Q](r)
+	if err == nil {
+		t.Fatal("expected validation error for limit > 100")
+	}
+}
+
+func TestBindQueryStructNoTag(t *testing.T) {
+	type Q struct {
+		Page   int `query:"page"`
+		Hidden int // no query tag — should be ignored
+	}
+	r, _ := http.NewRequest("GET", "/users?page=1&Hidden=99", nil)
+	q, err := BindQueryStruct[Q](r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if q.Hidden != 0 {
+		t.Errorf("Hidden = %d, want 0 (should be ignored)", q.Hidden)
+	}
+}
+
+func TestBindQueryStructDashTag(t *testing.T) {
+	type Q struct {
+		Skip int `query:"-"`
+	}
+	r, _ := http.NewRequest("GET", "/users?Skip=5", nil)
+	q, err := BindQueryStruct[Q](r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if q.Skip != 0 {
+		t.Errorf("Skip = %d, want 0", q.Skip)
+	}
+}
+
 // --- BindHeader edge-case tests ---
 
 func TestBindHeaderPresent(t *testing.T) {


### PR DESCRIPTION
## PR Checklist

- [x] Commit messages follow the project convention (`type :: scope - description`)
- [x] Tests have been added or updated for bug fixes / new features
- [x] Docs have been added or updated where necessary

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Code style update (formatting, naming)
- [ ] Build related changes
- [ ] Documentation
- [ ] Other — please describe:

## Related Issue

Closes #33

## New Behavior

Generic `BindQueryStruct[T]` function that binds URL query parameters to a typed struct, mirroring the `Bind[T]` API for request bodies.

```go
type ListQuery struct {
    Page  int      `query:"page"`
    Limit int      `query:"limit" validate:"max=100"`
    Sort  string   `query:"sort"  validate:"oneof=asc|desc"`
    Tags  []string `query:"tag"`
}

q, err := core.BindQueryStruct[ListQuery](r)
```

- Maps struct fields via `query` struct tag
- Auto-converts string values to `int`, `int64`, `uint`, `uint64`, `float32`, `float64`, `bool`
- Supports `[]string` for multi-value params (`?tag=a&tag=b`)
- Integrates with existing `validate` tag engine
- Existing `BindQuery(r, key)` remains unchanged (no breaking change)

## Breaking Changes

- [ ] Yes
- [x] No

## Additional Context

8 test cases added: basic binding, slice, bool/float, missing params, invalid type, validation, no tag, dash tag.