### PR TITLE
fix :: middleware - rate limiter key, CORS merge, guardReject, RealIP default

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -53,8 +53,9 @@ func NewApp() *App {
 // Use this to bring your own router while keeping the rest of Zenqo's features.
 func NewAppWith(adapter RouterAdapter) *App {
 	adapter.Use(middleware.RequestID)
-	adapter.Use(middleware.RealIP)
-	adapter.Use(zenqoRecoverer)
+	adapter.Use(middleware.RealIPWithConfig(middleware.RealIPConfig{
+		TrustedProxies: []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8", "::1/128"},
+	}))
 	adapter.NotFound(func(w http.ResponseWriter, r *http.Request) {
 		Error(w, 404, "not found")
 	})

--- a/core/middleware.go
+++ b/core/middleware.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -82,7 +83,8 @@ func applyGuard(g Guard, next http.HandlerFunc, errHandler ErrorHandlerFunc) htt
 // guardReject writes the appropriate error response when a Guard denies access.
 func guardReject(w http.ResponseWriter, err error) {
 	if err != nil {
-		if he, ok := err.(*HTTPError); ok {
+		var he *HTTPError
+		if errors.As(err, &he) {
 			JSON(w, he.Status, ErrorResponse{Code: he.Status, Message: he.Message})
 			return
 		}

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -38,7 +38,20 @@ func DefaultCORSConfig() CORSConfig {
 func CORS(configs ...CORSConfig) func(http.Handler) http.Handler {
 	cfg := DefaultCORSConfig()
 	if len(configs) > 0 {
-		cfg = configs[0]
+		c := configs[0]
+		if len(c.AllowOrigins) > 0 {
+			cfg.AllowOrigins = c.AllowOrigins
+		}
+		if len(c.AllowMethods) > 0 {
+			cfg.AllowMethods = c.AllowMethods
+		}
+		if len(c.AllowHeaders) > 0 {
+			cfg.AllowHeaders = c.AllowHeaders
+		}
+		if c.MaxAge != 0 {
+			cfg.MaxAge = c.MaxAge
+		}
+		cfg.AllowCredentials = c.AllowCredentials
 	}
 
 	// Guard against the invalid combination of wildcard origin + credentials.

--- a/middleware/ratelimit.go
+++ b/middleware/ratelimit.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"net"
 	"net/http"
 	"strconv"
 	"sync"
@@ -29,7 +30,11 @@ func DefaultRateLimitConfig() RateLimitConfig {
 		Max:    100,
 		Window: time.Minute,
 		KeyFunc: func(r *http.Request) string {
-			return r.RemoteAddr
+			host, _, err := net.SplitHostPort(r.RemoteAddr)
+			if err != nil {
+				return r.RemoteAddr
+			}
+			return host
 		},
 		OnLimit: func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/middleware/realip.go
+++ b/middleware/realip.go
@@ -1,9 +1,12 @@
 package middleware
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"strings"
+
+	zlog "github.com/zenqos/zenqo/internal/log"
 )
 
 // RealIP is a middleware that sets r.RemoteAddr to the client's real IP
@@ -89,14 +92,15 @@ func realIPFromHeaders(r *http.Request) string {
 	return ""
 }
 
-// parseCIDRs parses a slice of CIDR strings, silently ignoring invalid entries.
 func parseCIDRs(cidrs []string) []*net.IPNet {
 	result := make([]*net.IPNet, 0, len(cidrs))
 	for _, c := range cidrs {
 		_, ipNet, err := net.ParseCIDR(c)
-		if err == nil {
-			result = append(result, ipNet)
+		if err != nil {
+			zlog.Warn("RealIP", fmt.Sprintf("invalid CIDR %q: %v", c, err))
+			continue
 		}
+		result = append(result, ipNet)
 	}
 	return result
 }


### PR DESCRIPTION
## PR Checklist

- [x] Commit messages follow the project convention
- [ ] Tests have been added or updated for bug fixes / new features
- [x] Docs have been added or updated where necessary

## PR Type

- [x] Bugfix
- [ ] Feature

## Related Issue

Closes #99, #103, #105, #112

## New Behavior

- Rate limiter default key strips ephemeral port using `net.SplitHostPort` — rate limiting now works correctly per IP
- CORS partial config merges with defaults instead of replacing them — omitting `AllowMethods` no longer breaks preflight
- `guardReject` uses `errors.As` for wrapped `*HTTPError` support
- Default `NewApp()` uses `RealIPWithConfig` with private network CIDRs instead of unconditionally trusting all proxy headers

## Breaking Changes

- [x] Yes
- [ ] No

- Rate limiter keys change from `ip:port` to `ip` — existing rate limit buckets will reset on deploy
- RealIP middleware now only trusts headers from private network ranges by default