### PR TITLE
fix :: openapi - YAML format, security scheme names

### DIFF
--- a/openapi/security.go
+++ b/openapi/security.go
@@ -1,9 +1,20 @@
 package openapi
 
+import "strings"
+
 // SecurityDef pairs a scheme name with its definition for use in Config.Security.
 type SecurityDef struct {
 	name   string
 	scheme *SecurityScheme
+}
+
+func toSchemeID(s string) string {
+	s = strings.ReplaceAll(s, "-", "")
+	s = strings.ReplaceAll(s, "_", "")
+	if len(s) > 0 && s[0] >= 'A' && s[0] <= 'Z' {
+		s = strings.ToLower(s[:1]) + s[1:]
+	}
+	return s
 }
 
 // BearerAuth creates a Bearer token (JWT) security scheme.
@@ -31,7 +42,7 @@ func BearerAuth() SecurityDef {
 //	openapi.APIKeyHeader("X-API-Key")
 func APIKeyHeader(headerName string) SecurityDef {
 	return SecurityDef{
-		name: "apiKeyHeader",
+		name: toSchemeID(headerName),
 		scheme: &SecurityScheme{
 			Type: "apiKey",
 			In:   "header",
@@ -43,7 +54,7 @@ func APIKeyHeader(headerName string) SecurityDef {
 // APIKeyCookie creates an API key security scheme sent via a cookie.
 func APIKeyCookie(cookieName string) SecurityDef {
 	return SecurityDef{
-		name: "apiKeyCookie",
+		name: toSchemeID(cookieName),
 		scheme: &SecurityScheme{
 			Type: "apiKey",
 			In:   "cookie",

--- a/openapi/yaml.go
+++ b/openapi/yaml.go
@@ -55,10 +55,12 @@ func emitYAML(buf *strings.Builder, v any, depth int) {
 		for _, item := range val {
 			buf.WriteString(pad)
 			buf.WriteString("- ")
-			switch item.(type) {
-			case map[string]any, []any:
+			switch child := item.(type) {
+			case map[string]any:
+				emitYAMLMapInline(buf, child, depth+1)
+			case []any:
 				buf.WriteByte('\n')
-				emitYAML(buf, item, depth+1)
+				emitYAML(buf, child, depth+1)
 			default:
 				emitYAMLScalar(buf, item)
 			}
@@ -66,6 +68,33 @@ func emitYAML(buf *strings.Builder, v any, depth int) {
 
 	default:
 		emitYAMLScalar(buf, v)
+	}
+}
+
+// emitYAMLMapInline writes a map where the first key follows "- " on the same line.
+func emitYAMLMapInline(buf *strings.Builder, m map[string]any, depth int) {
+	pad := strings.Repeat("  ", depth)
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for i, k := range keys {
+		if i > 0 {
+			buf.WriteString(pad)
+		}
+		buf.WriteString(yamlKey(k))
+		buf.WriteByte(':')
+		child := m[k]
+		switch child.(type) {
+		case map[string]any, []any:
+			buf.WriteByte('\n')
+			emitYAML(buf, child, depth+1)
+		default:
+			buf.WriteByte(' ')
+			emitYAMLScalar(buf, child)
+		}
 	}
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] Commit messages follow the project convention
- [ ] Tests have been added or updated for bug fixes / new features
- [x] Docs have been added or updated where necessary

## PR Type

- [x] Bugfix
- [ ] Feature

## Related Issue

Closes #108, #109

## New Behavior

- YAML emitter places first key of map array items on the same line as the dash (`- key: value` instead of `- \n  key: value`)
- `APIKeyHeader` and `APIKeyCookie` derive scheme names from the header/cookie name to prevent collisions when registering multiple schemes of the same type

## Breaking Changes

- [ ] Yes
- [x] No