### PR TITLE
feat :: add SkipGlobalPrefix to BaseController

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -205,6 +205,14 @@ func (a *App) buildRoutes() {
 		for _, g := range a.globalGuards {
 			a.adapter.Use(guardToMiddleware(g, errHandler))
 		}
+		type prefixSkipper interface{ isSkippingPrefix() bool }
+		skipsPrefix := func(c Controller) bool {
+			if s, ok := c.(prefixSkipper); ok {
+				return s.isSkippingPrefix()
+			}
+			return false
+		}
+
 		mount := func(r Router) {
 			for _, m := range a.modules {
 				for _, c := range m.Controllers() {
@@ -219,8 +227,38 @@ func (a *App) buildRoutes() {
 			}
 		}
 		if a.prefix != "" {
+			// Controllers that called SkipGlobalPrefix() are mounted at root.
+			a.adapter.Mount(func(r Router) {
+				for _, m := range a.modules {
+					for _, c := range m.Controllers() {
+						if skipsPrefix(c) {
+							c.RegisterRoutes(r)
+						}
+					}
+				}
+				for _, c := range a.controllers {
+					if skipsPrefix(c) {
+						c.RegisterRoutes(r)
+					}
+				}
+			})
+			// Everything else goes under the global prefix.
 			a.adapter.Route(a.prefix, func(r Router) {
-				mount(r)
+				for _, m := range a.modules {
+					for _, c := range m.Controllers() {
+						if !skipsPrefix(c) {
+							c.RegisterRoutes(r)
+						}
+					}
+				}
+				for _, c := range a.controllers {
+					if !skipsPrefix(c) {
+						c.RegisterRoutes(r)
+					}
+				}
+				if len(a.root.routes) > 0 {
+					a.root.RegisterRoutes(r)
+				}
 			})
 		} else {
 			a.adapter.Mount(mount)

--- a/core/app_routes.go
+++ b/core/app_routes.go
@@ -17,6 +17,14 @@ func (a *App) CollectRoutes() []RouteEntry {
 	var entries []RouteEntry
 	prefix := a.prefix
 
+	type prefixSkipper interface{ isSkippingPrefix() bool }
+	effectivePrefix := func(c Controller) string {
+		if s, ok := c.(prefixSkipper); ok && s.isSkippingPrefix() {
+			return ""
+		}
+		return prefix
+	}
+
 	add := func(c Controller, pathPrefix string) {
 		rp, ok := c.(RouteProvider)
 		if !ok {
@@ -34,11 +42,11 @@ func (a *App) CollectRoutes() []RouteEntry {
 
 	for _, m := range a.modules {
 		for _, c := range m.Controllers() {
-			add(c, prefix)
+			add(c, effectivePrefix(c))
 		}
 	}
 	for _, c := range a.controllers {
-		add(c, prefix)
+		add(c, effectivePrefix(c))
 	}
 	// Top-level routes registered directly on the app (app.GET/POST/etc.)
 	for _, rd := range a.root.routes {

--- a/core/controller.go
+++ b/core/controller.go
@@ -116,6 +116,7 @@ func (rd *RouteDefinition) Use(mw ...MiddlewareFunc) *RouteDefinition {
 // via UseControllerGuard, UseControllerInterceptor, and UseControllerMiddleware.
 type BaseController struct {
 	basePath     string
+	skipPrefix   bool
 	routes       []*RouteDefinition
 	guards       []Guard
 	interceptors []Interceptor
@@ -143,6 +144,23 @@ func (bc *BaseController) SetBasePath(p string) {
 
 // BasePath returns the URL prefix for this controller.
 func (bc *BaseController) BasePath() string { return bc.basePath }
+
+// SkipGlobalPrefix marks this controller to be mounted at the root path,
+// bypassing any global prefix set via SetGlobalPrefix.
+//
+// Example:
+//
+//	func NewController() *HealthController {
+//	    c := &HealthController{}
+//	    c.SetBasePath("/health")
+//	    c.SkipGlobalPrefix()
+//	    return c
+//	}
+func (bc *BaseController) SkipGlobalPrefix() {
+	bc.skipPrefix = true
+}
+
+func (bc *BaseController) isSkippingPrefix() bool { return bc.skipPrefix }
 
 // Routes returns all route definitions registered on this controller.
 // Implements the RouteProvider interface used by the OpenAPI spec generator.


### PR DESCRIPTION
## PR Checklist

- [x] Commit messages follow the project convention (`type :: scope - description`)
- [x] Tests have been added or updated for bug fixes / new features
- [x] Docs have been added or updated where necessary

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Code style update (formatting, naming)
- [ ] Build related changes
- [ ] Documentation
- [ ] Other — please describe:

## Related Issue

Closes #139

## New Behavior

Controllers can now call `SkipGlobalPrefix()` to opt out of the global prefix set via `SetGlobalPrefix()`.

```go
func NewHealthController() *HealthController {
    c := &HealthController{}
    c.SetBasePath("/health")
    c.SkipGlobalPrefix() // mounted at /health, not /api/v1/health
    return c
}
```

- Controllers that call `SkipGlobalPrefix()` are mounted at root
- All other controllers remain under the global prefix
- `CollectRoutes()` updated so OpenAPI docs reflect the correct paths

## Breaking Changes

- [x] No

## Additional Context

Mirrors the controller-level opt-out pattern, keeping `SetGlobalPrefix()` simple with no extra parameters.