### PR TITLE
feat :: improve CLI installation experience

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Read version
         id: version
         run: |
@@ -31,47 +35,21 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Get previous tag
-        if: steps.check.outputs.exists == 'false'
-        id: prev
-        run: |
-          tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
-      - name: Generate release notes
-        if: steps.check.outputs.exists == 'false'
-        id: notes
-        run: |
-          prev="${{ steps.prev.outputs.tag }}"
-          next="${{ steps.version.outputs.version }}"
-          range="HEAD"
-          if [ -n "$prev" ]; then
-            range="${prev}..HEAD"
-          fi
-
-          {
-            echo "notes<<NOTES_EOF"
-            echo "## Changes"
-            echo ""
-            git log "$range" --oneline --no-merges | while read -r line; do
-              echo "- $line"
-            done
-            echo ""
-            if [ -n "$prev" ]; then
-              echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${prev}...${next}"
-            fi
-            echo "NOTES_EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Create release
+      - name: Create tag
         if: steps.check.outputs.exists == 'false'
         run: |
-          gh release create "${{ steps.version.outputs.version }}" \
-            --target main \
-            --title "${{ steps.version.outputs.version }}" \
-            --notes "${{ steps.notes.outputs.notes }}"
+          git tag "${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.version }}"
+
+      - name: Run GoReleaser
+        if: steps.check.outputs.exists == 'false'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Trigger pkg.go.dev update
         if: steps.check.outputs.exists == 'false'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,51 @@
+version: 2
+
+builds:
+  - id: zenqo
+    main: ./cmd/zenqo
+    binary: zenqo
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+
+archives:
+  - id: zenqo
+    builds: [zenqo]
+    name_template: "zenqo_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - none*
+
+checksum:
+  name_template: "checksums.txt"
+
+release:
+  github:
+    owner: zenqos
+    name: zenqo
+  name_template: "{{ .Tag }}"
+
+brews:
+  - name: zenqo
+    repository:
+      owner: zenqos
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: "https://github.com/zenqos/zenqo"
+    description: "CLI tool for the Zenqo web framework"
+    license: MIT
+    install: bin.install "zenqo"
+    test: system "#{bin}/zenqo", "--help"

--- a/cmd/zenqo/dev.go
+++ b/cmd/zenqo/dev.go
@@ -116,40 +116,7 @@ func runWithWatch(dir, entry string) error {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
-	var cmd *exec.Cmd
-
-	start := func() *exec.Cmd {
-		c := exec.Command("go", "run", target)
-		c.Stdout = os.Stdout
-		c.Stderr = os.Stderr
-		c.Stdin = os.Stdin
-		c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-		if err := c.Start(); err != nil {
-			fmt.Fprintf(os.Stderr, "  ❌ failed to start: %v\n", err)
-			return nil
-		}
-		return c
-	}
-
-	stop := func(c *exec.Cmd) {
-		if c == nil || c.Process == nil {
-			return
-		}
-		_ = syscall.Kill(-c.Process.Pid, syscall.SIGTERM)
-		done := make(chan struct{})
-		go func() {
-			c.Wait() //nolint:errcheck
-			close(done)
-		}()
-		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			_ = syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
-			<-done
-		}
-	}
-
-	cmd = start()
+	var cmd = startCmd(target)
 
 	snapshot := collectGoFileModTimes(".")
 
@@ -159,7 +126,7 @@ func runWithWatch(dir, entry string) error {
 	for {
 		select {
 		case <-quit:
-			stop(cmd)
+			stopCmd(cmd)
 			fmt.Println("\n  👋 stopped")
 			return nil
 		case <-ticker.C:
@@ -167,8 +134,8 @@ func runWithWatch(dir, entry string) error {
 			if !modTimesEqual(snapshot, current) {
 				snapshot = current
 				fmt.Println("\n  🔄 change detected, restarting...")
-				stop(cmd)
-				cmd = start()
+				stopCmd(cmd)
+				cmd = startCmd(target)
 			}
 		}
 	}

--- a/cmd/zenqo/dev_unix.go
+++ b/cmd/zenqo/dev_unix.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+func startCmd(target string) *exec.Cmd {
+	c := exec.Command("go", "run", target)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Stdin = os.Stdin
+	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := c.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "  ❌ failed to start: %v\n", err)
+		return nil
+	}
+	return c
+}
+
+func stopCmd(c *exec.Cmd) {
+	if c == nil || c.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-c.Process.Pid, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		c.Wait() //nolint:errcheck
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		_ = syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
+		<-done
+	}
+}

--- a/cmd/zenqo/dev_windows.go
+++ b/cmd/zenqo/dev_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+func startCmd(target string) *exec.Cmd {
+	c := exec.Command("go", "run", target)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Stdin = os.Stdin
+	// CREATE_NEW_PROCESS_GROUP lets us send Ctrl+Break to the child tree.
+	c.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+	if err := c.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "  ❌ failed to start: %v\n", err)
+		return nil
+	}
+	return c
+}
+
+func stopCmd(c *exec.Cmd) {
+	if c == nil || c.Process == nil {
+		return
+	}
+	// Kill the entire process tree (/T) forcefully (/F).
+	exec.Command("taskkill", "/F", "/T", "/PID", fmt.Sprint(c.Process.Pid)).Run() //nolint:errcheck
+	done := make(chan struct{})
+	go func() {
+		c.Wait() //nolint:errcheck
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		c.Process.Kill() //nolint:errcheck
+		<-done
+	}
+}

--- a/docs/getting-started.ko.md
+++ b/docs/getting-started.ko.md
@@ -4,13 +4,56 @@
 
 ## 설치
 
+### macOS
+
 ```bash
-# Go
+# Homebrew (권장)
+brew install zenqos/tap/zenqo
+
+# 확인
+zenqo --help
+```
+
+### Linux
+
+```bash
+# 설치 스크립트 한 줄로 설치
+curl -fsSL https://raw.githubusercontent.com/zenqos/zenqo/main/install.sh | sh
+
+# 확인
+zenqo --help
+```
+
+### Windows
+
+**관리자 권한으로 PowerShell**을 열고 실행:
+
+```powershell
+irm https://raw.githubusercontent.com/zenqos/zenqo/main/install.ps1 | iex
+```
+
+바이너리가 `%LOCALAPPDATA%\zenqo`에 설치되고 PATH에 자동으로 추가됩니다.
+
+```powershell
+# 확인 (새 터미널에서)
+zenqo --help
+```
+
+### go install (전 플랫폼)
+
+Go 1.21 이상 필요. 바이너리는 `$GOPATH/bin`에 설치됩니다.
+
+```bash
 go install github.com/zenqos/zenqo/cmd/zenqo@latest
 
-# Homebrew
-brew install zenqos/tap/zenqo
+# PATH에 추가 (아직 없다면 ~/.zshrc 또는 ~/.bashrc에 추가)
+export PATH="$PATH:$(go env GOPATH)/bin"
+
+# 확인
+zenqo --help
 ```
+
+---
 
 ## 새 프로젝트 생성
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,13 +4,56 @@
 
 ## Install
 
+### macOS
+
 ```bash
-# Go
+# Homebrew (recommended)
+brew install zenqos/tap/zenqo
+
+# Verify
+zenqo --help
+```
+
+### Linux
+
+```bash
+# One-liner install script
+curl -fsSL https://raw.githubusercontent.com/zenqos/zenqo/main/install.sh | sh
+
+# Verify
+zenqo --help
+```
+
+### Windows
+
+Open **PowerShell as Administrator** and run:
+
+```powershell
+irm https://raw.githubusercontent.com/zenqos/zenqo/main/install.ps1 | iex
+```
+
+This downloads the binary to `%LOCALAPPDATA%\zenqo` and adds it to your PATH automatically.
+
+```powershell
+# Verify (open a new terminal)
+zenqo --help
+```
+
+### via go install (all platforms)
+
+Requires Go 1.21+. The binary is placed in `$GOPATH/bin`.
+
+```bash
 go install github.com/zenqos/zenqo/cmd/zenqo@latest
 
-# Homebrew
-brew install zenqos/tap/zenqo
+# Add to PATH if not already (add this line to ~/.zshrc or ~/.bashrc)
+export PATH="$PATH:$(go env GOPATH)/bin"
+
+# Verify
+zenqo --help
 ```
+
+---
 
 ## Scaffold a New Project
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,43 @@
+$ErrorActionPreference = "Stop"
+
+$Repo    = "zenqos/zenqo"
+$InstallDir = "$env:LOCALAPPDATA\zenqo"
+
+# Fetch latest version
+$Release = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest"
+$Version = $Release.tag_name
+
+$Filename = "zenqo_windows_amd64.zip"
+$Url      = "https://github.com/$Repo/releases/download/$Version/$Filename"
+
+Write-Host "Installing zenqo $Version (windows/amd64)..."
+
+# Download and extract
+$Tmp = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
+try {
+    Invoke-WebRequest -Uri $Url -OutFile "$Tmp\$Filename" -UseBasicParsing
+    Expand-Archive -Path "$Tmp\$Filename" -DestinationPath $Tmp -Force
+
+    # Install binary
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir | Out-Null
+    }
+    Move-Item -Force "$Tmp\zenqo.exe" "$InstallDir\zenqo.exe"
+} finally {
+    Remove-Item -Recurse -Force $Tmp -ErrorAction SilentlyContinue
+}
+
+# Add to PATH if not already there
+$CurrentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($CurrentPath -notlike "*$InstallDir*") {
+    [Environment]::SetEnvironmentVariable("Path", "$CurrentPath;$InstallDir", "User")
+    $env:Path += ";$InstallDir"
+    Write-Host "Added $InstallDir to PATH."
+}
+
+Write-Host ""
+Write-Host "zenqo $Version installed to $InstallDir\zenqo.exe"
+Write-Host ""
+Write-Host "Get started:"
+Write-Host "  zenqo new my-app"
+Write-Host "  cd my-app && zenqo dev"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+set -e
+
+REPO="zenqos/zenqo"
+INSTALL_DIR="/usr/local/bin"
+
+# Detect OS
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$OS" in
+  linux)  OS="linux" ;;
+  darwin) OS="darwin" ;;
+  *)
+    echo "Unsupported OS: $OS"
+    echo "Please download manually from https://github.com/$REPO/releases"
+    exit 1
+    ;;
+esac
+
+# Detect architecture
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64)        ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *)
+    echo "Unsupported architecture: $ARCH"
+    echo "Please download manually from https://github.com/$REPO/releases"
+    exit 1
+    ;;
+esac
+
+# Fetch latest version
+VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+  | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+
+if [ -z "$VERSION" ]; then
+  echo "Failed to fetch latest version. Check your internet connection."
+  exit 1
+fi
+
+FILENAME="zenqo_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/$REPO/releases/download/$VERSION/$FILENAME"
+
+echo "Installing zenqo $VERSION ($OS/$ARCH)..."
+
+# Download and extract
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+curl -fsSL "$URL" -o "$TMP/$FILENAME"
+tar -xzf "$TMP/$FILENAME" -C "$TMP"
+
+# Install binary
+if [ -w "$INSTALL_DIR" ]; then
+  mv "$TMP/zenqo" "$INSTALL_DIR/zenqo"
+else
+  echo "Installing to $INSTALL_DIR (requires sudo)..."
+  sudo mv "$TMP/zenqo" "$INSTALL_DIR/zenqo"
+fi
+chmod +x "$INSTALL_DIR/zenqo"
+
+echo ""
+echo "zenqo $VERSION installed to $INSTALL_DIR/zenqo"
+echo ""
+echo "Get started:"
+echo "  zenqo new my-app"
+echo "  cd my-app && zenqo dev"


### PR DESCRIPTION
## PR Checklist

- [x] Commit messages follow the project convention (`type :: scope - description`)
- [ ] Tests have been added or updated for bug fixes / new features
- [x] Docs have been added or updated where necessary

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Code style update (formatting, naming)
- [x] Build related changes
- [x] Documentation
- [ ] Other — please describe:

## Related Issue

Closes #140

## New Behavior

Users on all platforms can now install zenqo without needing Go installed.

**macOS**
```bash
brew install zenqos/tap/zenqo
```

**Linux**
```bash
curl -fsSL https://raw.githubusercontent.com/zenqos/zenqo/main/install.sh | sh
```

**Windows**
```powershell
irm https://raw.githubusercontent.com/zenqos/zenqo/main/install.ps1 | iex
```

Changes:
- Add `install.sh` — macOS/Linux one-liner, auto-detects OS/arch, installs to `/usr/local/bin`
- Add `install.ps1` — Windows PowerShell one-liner, installs to `%LOCALAPPDATA%\zenqo` and auto-adds to PATH
- Add `.goreleaser.yaml` — builds platform-specific binaries (macOS/Linux/Windows) and auto-updates Homebrew formula on release
- Update `release.yml` — uses GoReleaser instead of manual `gh release create`
- Fix `zenqo dev --watch` on Windows by splitting process management into `dev_unix.go` / `dev_windows.go`
- Update getting-started docs (en/ko) with per-OS install instructions including PATH setup for `go install`

## Breaking Changes

- [x] No

## Additional Context

`HOMEBREW_TAP_TOKEN` secret (fine-grained PAT with write access to `zenqos/homebrew-tap`) must be added to repo secrets for the Homebrew formula auto-update to work.